### PR TITLE
Fix GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Build project 🛠️
         run: npm run build # This runs 'vite build' and creates the 'dist' folder
 
+      - name: Copy CNAME
+        run: cp CNAME dist/CNAME
+
       - name: Setup Pages 🛠️
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
## Summary
- add a step to copy `CNAME` into the deployment folder so the custom domain is served from the GitHub Pages artifact

## Testing
- `npm run build`
