### PR TITLE
Ensure GitHub Pages loads SPA correctly

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=./" />
+  </head>
+  <body></body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: './',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- set `base: './'` in Vite config so assets resolve relative to the current path
- add a simple `404.html` page to redirect unmatched routes to the SPA entry

## Testing
- `npm run build`